### PR TITLE
Remove announcements.proto definition

### DIFF
--- a/proto/plugin-adapter/api/announcements.proto
+++ b/proto/plugin-adapter/api/announcements.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-package PluginAdapter.Api;
-import "announcement.proto";
-
-message Announcements {
-  repeated Announcement announcements = 1;
-}


### PR DESCRIPTION
The announcements.proto definition is not longer needed.